### PR TITLE
unused min_tc gone from 2 steps; param moved to top level in config

### DIFF
--- a/python/inner-sample-molecules-RNN.py
+++ b/python/inner-sample-molecules-RNN.py
@@ -17,7 +17,6 @@ parser = argparse.ArgumentParser()
 ## build the CLI
 parser.add_argument('--database', type=str)
 parser.add_argument('--representation', type=str)
-parser.add_argument('--min_tc', type=int)
 parser.add_argument('--rnn_type', type=str)
 parser.add_argument('--embedding_size', type=int)
 parser.add_argument('--hidden_size', type=int)

--- a/python/inner-train-models-RNN.py
+++ b/python/inner-train-models-RNN.py
@@ -24,7 +24,6 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument('--database', type=str)
 parser.add_argument('--representation', type=str)
-parser.add_argument('--min_tc', type=int)
 parser.add_argument('--seed', type=int)
 parser.add_argument('--rnn_type', type=str)
 parser.add_argument('--embedding_size', type=int)

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -87,7 +87,7 @@ rule create_training_sets:
         '--enum-factor {wildcards.enum_factor} '
         '--folds {FOLDS} '
         '--representation {wildcards.repr} '
-        '--min-tc 0 '
+        '--min-tc {config[min_tc]} '
         '--max-input-smiles {config[max_input_smiles]} '
 
 
@@ -134,7 +134,6 @@ rule train_models_RNN:
             'python ../python/inner-train-models-RNN.py '
             '--database {wildcards.dataset} '
             '--representation {wildcards.repr} '
-            '--min_tc {MODEL_PARAMS[min_tc]} '
             '--seed {wildcards.seed} '
             '--rnn_type {MODEL_PARAMS[rnn_type]} '
             '--embedding_size {MODEL_PARAMS[embedding_size]} '
@@ -172,7 +171,6 @@ rule sample_molecules_RNN:
         'python ../python/inner-sample-molecules-RNN.py '
         '--database {wildcards.dataset} '
         '--representation {wildcards.repr} '
-        '--min_tc {MODEL_PARAMS[min_tc]} '
         '--rnn_type {MODEL_PARAMS[rnn_type]} '
         '--embedding_size {MODEL_PARAMS[embedding_size]} '
         '--hidden_size {MODEL_PARAMS[hidden_size]} '

--- a/snakemake/config.json
+++ b/snakemake/config.json
@@ -10,7 +10,6 @@
   "max_input_smiles": 0,
 
   "model_params": {
-    "min_tc": 0,
     "rnn_type": "LSTM",
     "embedding_size": 128,
     "hidden_size": 1024,
@@ -27,6 +26,7 @@
 
   "metrics": ["freq-sum", "freq-avg", "fp10k"],
 
+  "min_tc": 0,
   "top_k": 30,
   "err_ppm": 10
 

--- a/snakemake/config_fast.json
+++ b/snakemake/config_fast.json
@@ -10,7 +10,6 @@
   "max_input_smiles": 1000,
 
   "model_params": {
-    "min_tc": 0,
     "rnn_type": "LSTM",
     "embedding_size": 32,
     "hidden_size": 256,
@@ -27,6 +26,7 @@
 
   "metrics": ["freq-avg"],
 
+  "min_tc": 0,
   "top_k": 30,
   "err_ppm": 10
 


### PR DESCRIPTION
`min_tc` is unused in `train_models` and `sample_molecules` steps. Moved to top level instead of as a model parameter, since it's only used in `create_training_sets`.