### PR TITLE
Fix CLI args for forecast.py

### DIFF
--- a/src/clm/commands/forecast.py
+++ b/src/clm/commands/forecast.py
@@ -20,13 +20,13 @@ logger = logging.getLogger(__name__)
 
 def add_args(parser):
     parser.add_argument(
-        "--test-file", type=str, required=True, help="File path of test file"
+        "--test_file", type=str, required=True, help="File path of test file"
     )
     parser.add_argument(
-        "--sample-file", type=str, required=True, help="File path of sample file"
+        "--sample_file", type=str, required=True, help="File path of sample file"
     )
     parser.add_argument(
-        "--output-file", type=str, required=True, help="File path of output file"
+        "--output_file", type=str, required=True, help="File path of output file"
     )
     parser.add_argument(
         "--max-mols",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -301,9 +301,9 @@ rule forecast:
         runtime=30,
     shell:
         'clm forecast '
-        '--test-file {input.test_file} '
-        '--sample-file {input.sample_file} '
-        '--output-file {output.output_file} '
+        '--test_file {input.test_file} '
+        '--sample_file {input.sample_file} '
+        '--output_file {output.output_file} '
         '--seed {config[random_seed]} '
 
 


### PR DESCRIPTION
Dashes in CLI args break compatibility with some bash scripts outside CLM repo.