### PR TITLE
Revert "log removal of invalid SMILES with examples"

### DIFF
--- a/src/clm/commands/write_structural_prior_CV.py
+++ b/src/clm/commands/write_structural_prior_CV.py
@@ -260,22 +260,7 @@ def write_structural_prior_CV(
             lambda s: clean_mol(s, raise_error=False) is None
         )
     ]
-
     gen = gen.drop(invalid_idx)
-
-    n_candidates = len(candidates)
-    n_invalid = len(invalid_idx)
-
-    # log if invalid SMILES were detected and removed
-    if n_invalid > 0:
-        examples = gen.loc[invalid_idx, "smiles"].head(5).tolist()
-
-        logger.warning(
-            f"Removed {n_invalid} invalid SMILES among "
-            f"{n_candidates} candidates to match a test molecule "
-            f"(possibly due to a different rdkit version). "
-            f"Examples: {examples}"
-        )
 
     inputs = {"model": gen.assign(source="model")}
 

--- a/src/clm/commands/write_structural_prior_CV.py
+++ b/src/clm/commands/write_structural_prior_CV.py
@@ -260,6 +260,21 @@ def write_structural_prior_CV(
             lambda s: clean_mol(s, raise_error=False) is None
         )
     ]
+
+    n_candidates = len(candidates)
+    n_invalid = len(invalid_idx)
+
+    # log if invalid SMILES were detected and removed
+    if n_invalid > 0:
+        examples = gen.loc[invalid_idx, "smiles"].head(5).tolist()
+
+        logger.warning(
+            f"Removed {n_invalid} invalid SMILES among "
+            f"{n_candidates} candidates to match a test molecule "
+            f"(possibly due to a different rdkit version). "
+            f"Examples: {examples}"
+        )
+
     gen = gen.drop(invalid_idx)
 
     inputs = {"model": gen.assign(source="model")}


### PR DESCRIPTION
Reverts commit 89d48039c17476686aca5bc1a85557c8c3237fab because we cannot print indices that have been dropped from the data frame.

```
Traceback (most recent call last):
  File "/Genomics/skinniderlab/darknps2/env-s4/bin/clm", line 7, in <module>
    sys.exit(main())
  File "/Genomics/argo/users/ms0270/git/CLM/src/clm/__main__.py", line 81, in main
    args.func(args)
  File "/Genomics/argo/users/ms0270/git/CLM/src/clm/commands/write_structural_prior_CV.py", line 364, in main
    write_structural_prior_CV(
  File "/Genomics/argo/users/ms0270/git/CLM/src/clm/commands/write_structural_prior_CV.py", line 271, in write_structural_prior_CV
    examples = gen.loc[invalid_idx, "smiles"].head(5).tolist()
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1185, in __getitem__
    return self._getitem_tuple(key)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1369, in _getitem_tuple
    return self._getitem_lowerdim(tup)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1090, in _getitem_lowerdim
    return getattr(section, self.name)[new_key]
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1192, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1421, in _getitem_axis
    return self._getitem_iterable(key, axis=axis)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1361, in _getitem_iterable
    keyarr, indexer = self._get_listlike_indexer(key, axis)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexing.py", line 1559, in _get_listlike_indexer
    keyarr, indexer = ax._get_indexer_strict(key, axis_name)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6212, in _get_indexer_strict
    self._raise_if_missing(keyarr, indexer, axis_name)
  File "/Genomics/skinniderlab/darknps2/env-s4/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6261, in _raise_if_missing
    raise KeyError(f"None of [{key}] are in the [{axis_name}]")
KeyError: "None of [Index([1280917], dtype='int64')] are in the [index]"
```